### PR TITLE
feat: assign sky fibers using sky table in targetdb

### DIFF
--- a/examples/commissioning_2022sep/pointing_utils/nfutils.py
+++ b/examples/commissioning_2022sep/pointing_utils/nfutils.py
@@ -42,12 +42,7 @@ from procedures.moduleTest.cobraCoach import CobraCoach
 #
 # NOTE: Do we still need the getBench function?
 #
-def getBench(
-    pfs_instdata_dir,
-    cobra_coach_dir,
-    cobra_coach_module_version,
-    sm
-):
+def getBench(pfs_instdata_dir, cobra_coach_dir, cobra_coach_module_version, sm):
 
     os.environ["PFS_INSTDATA_DIR"] = pfs_instdata_dir
     cobraCoach = CobraCoach(
@@ -338,47 +333,49 @@ def fiber_allocation(
 
     # exit()
 
-    cobra_coach, bench = getBench(pfs_instdata_dir, cobra_coach_dir, cobra_coach_module_version, sm)
+    cobra_coach, bench = getBench(
+        pfs_instdata_dir, cobra_coach_dir, cobra_coach_module_version, sm
+    )
 
-    #os.environ["PFS_INSTDATA_DIR"] = pfs_instdata_dir
-    #cobra_coach = CobraCoach(
+    # os.environ["PFS_INSTDATA_DIR"] = pfs_instdata_dir
+    # cobra_coach = CobraCoach(
     #    "fpga", loadModel=False, trajectoryMode=True, rootDir=cobra_coach_dir
-    #)
+    # )
 
-    #cobra_coach.loadModel(version="ALL", moduleVersion=cobra_coach_module_version)
+    # cobra_coach.loadModel(version="ALL", moduleVersion=cobra_coach_module_version)
 
-    #calibration_product = cobra_coach.calibModel
+    # calibration_product = cobra_coach.calibModel
 
     # load Bench with the default setting
-    #bench = Bench(layout="full")
+    # bench = Bench(layout="full")
 
     # copy values into calibration_product using the default Bench object
-    #calibration_product.status = bench.cobras.status.copy()
-    #calibration_product.tht0 = bench.cobras.tht0.copy()
-    #calibration_product.tht1 = bench.cobras.tht1.copy()
-    #calibration_product.phiIn = bench.cobras.phiIn.copy()
-    #calibration_product.phiOut = bench.cobras.phiOut.copy()
-    #calibration_product.L1 = bench.cobras.L1.copy()
-    #calibration_product.L2 = bench.cobras.L2.copy()
+    # calibration_product.status = bench.cobras.status.copy()
+    # calibration_product.tht0 = bench.cobras.tht0.copy()
+    # calibration_product.tht1 = bench.cobras.tht1.copy()
+    # calibration_product.phiIn = bench.cobras.phiIn.copy()
+    # calibration_product.phiOut = bench.cobras.phiOut.copy()
+    # calibration_product.L1 = bench.cobras.L1.copy()
+    # calibration_product.L2 = bench.cobras.L2.copy()
 
     # Limit spectral modules
-    #gfm = FiberIds()  # 2604
-    #cobra_ids_use = np.array([], dtype=np.uint16)
-    #for sm_use in sm:
+    # gfm = FiberIds()  # 2604
+    # cobra_ids_use = np.array([], dtype=np.uint16)
+    # for sm_use in sm:
     #    cobra_ids_use = np.append(cobra_ids_use, gfm.cobrasForSpectrograph(sm_use))
 
     ## print(cobra_ids_use)
 
     # set Bad Cobra status for unused spectral modules
-    #for cobra_id in range(calibration_product.nCobras):
+    # for cobra_id in range(calibration_product.nCobras):
     #    if cobra_id not in cobra_ids_use:
     #        calibration_product.status[cobra_id] = ~PFIDesign.COBRA_OK_MASK
 
     # load Bench with the updated calibration products
-    #bench = Bench(
+    # bench = Bench(
     #    layout="calibration",
     #    calibrationProduct=calibration_product,
-    #)
+    # )
 
     # create the dictionary containing the costs and constraints for all classes
     # of targets

--- a/examples/commissioning_2022sep/subaru_fiber_allocation.py
+++ b/examples/commissioning_2022sep/subaru_fiber_allocation.py
@@ -299,7 +299,12 @@ def main():
         mag_filter=args.fluxstd_mag_filter,
         min_prob_f_star=args.fluxstd_min_prob_f_star,
     )
-    df_sky = pd.DataFrame()
+    df_sky = dbutils.generate_skyobjects_from_targetdb(
+        args.ra,
+        args.dec,
+        conf=conf,
+        # extra_where="LIMIT 1000",
+    )
 
     if args.raster_scan:
         df_raster = dbutils.generate_targets_from_gaiadb(


### PR DESCRIPTION
note: because of the current non-homogenized way of assigning `obj_id` in `sky` table, there is a possibility to have multiple `(obj_id, cat_id)` pairs in a `pfsDesign`. I used `sky_id` which is uniquely assigned in the table, but we need to come up with an idea to a coherent way of naming scheme for `obj_id`.