### PR TITLE
rename the project to ets_target_database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
-name = "targetdb"
+# name = "targetdb"
+name = "ets_target_database"
 # version = "0.1.0"
 dynamic = ["version"]
 description = "PFS target database (targetDB) tools"


### PR DESCRIPTION
This PR renames the package name from `targetdb` to `ets_target_database` because `targetdb` is already taken by someone (and registered to pypi).

This does not affect the actual coding. You can keep importing the package as 

```python
from targetdb import TargetDB
```

Note that it may still conflict with the other `targetdb` package. Please let me know if you have any problem. I strongly recommend to create a dedicated venv for the project.