### PR TITLE
Fix immutabledict error by avoiding pd.read_sql()

### DIFF
--- a/src/targetdb/targetdb.py
+++ b/src/targetdb/targetdb.py
@@ -215,8 +215,11 @@ class TargetDB(object):
         """
         model = getattr(models, tablename)
         try:
-            # Use session.connection() instead of session.bind for SQLAlchemy 2.x compatibility
-            df = pd.read_sql(self.session.query(model).statement, self.session.connection())
+            # Use session.execute() to avoid immutabledict issues with pd.read_sql()
+            result = self.session.execute(self.session.query(model).statement)
+            columns = result.keys()
+            data = result.fetchall()
+            df = pd.DataFrame(data, columns=columns)
         except:
             self.session.rollback()
             raise
@@ -243,8 +246,11 @@ class TargetDB(object):
         for k, v in kwargs.items():
             query = query.filter(getattr(model, k) == v)
         try:
-            # Use session.connection() instead of session.bind for SQLAlchemy 2.x compatibility
-            df = pd.read_sql(query.statement, self.session.connection())
+            # Use session.execute() to avoid immutabledict issues with pd.read_sql()
+            result = self.session.execute(query.statement)
+            columns = result.keys()
+            data = result.fetchall()
+            df = pd.DataFrame(data, columns=columns)
         except:
             self.session.rollback()
             raise
@@ -266,8 +272,11 @@ class TargetDB(object):
         ----
         """
         try:
-            # Use session.connection() instead of session.bind for SQLAlchemy 2.x compatibility
-            df = pd.read_sql(query, self.session.connection())
+            # Use session.execute() with text() to avoid immutabledict issues with pd.read_sql()
+            result = self.session.execute(text(query))
+            columns = result.keys()
+            data = result.fetchall()
+            df = pd.DataFrame(data, columns=columns)
         except:
             self.session.rollback()
             raise


### PR DESCRIPTION
## Summary
- Replace `pd.read_sql()` with `session.execute()` in all fetch methods to avoid immutabledict compatibility issues
- Previous fix (#116) only changed connection acquisition but `pd.read_sql()` itself was causing the error
- Modified `fetch_all()`, `fetch_by_id()`, and `fetch_query()` to manually construct DataFrames from query results

## Changes
- `fetch_all()`: Use `session.execute()` and manually construct DataFrame
- `fetch_by_id()`: Use `session.execute()` and manually construct DataFrame  
- `fetch_query()`: Use `session.execute(text())` and manually construct DataFrame

## Related
Fixes the root cause of immutabledict errors reported after #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)