### PR TITLE
Pin mkdocs to <2 and remove unused mkdocstrings-python

### DIFF
--- a/.github/workflows/deploy_docs_github_pages.yml
+++ b/.github/workflows/deploy_docs_github_pages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build documentation
-        run: uvx --python 3.12 --with "mkdocs-material[imaging]" --with mkdocstrings-python mkdocs build --site-dir _site
+        run: uvx --python 3.12 --with "mkdocs-material[imaging]" "mkdocs<2" build --site-dir _site
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pfs-targetdb-cli = "targetdb.cli.cli_main:app"
 
 [project.optional-dependencies]
 dev = ["ipython", "pytest", "black", "ruff", "setuptools-scm>=8.0"]
-doc = ["mkdocs", "mkdocs-material[imaging]", "mkdocstrings-python"]
+doc = ["mkdocs<2", "mkdocs-material[imaging]"]
 
 [build-system]
 requires = ["setuptools>=64", "setuptools-scm>=8.0", "wheel"]


### PR DESCRIPTION
- Pin mkdocs to <2 to avoid MkDocs 2.0 breaking changes (plugin system removed, no migration path)
- Remove mkdocstrings-python which is not used in mkdocs.yml