### PR TITLE
Add u- and v-band filter and photometric columns to target and fluxstd tables

### DIFF
--- a/alembic/pfsa-db01-gb/alembic/versions/20260520-181828_5df293bb75f2_add_filter_u_and_change_accordingly.py
+++ b/alembic/pfsa-db01-gb/alembic/versions/20260520-181828_5df293bb75f2_add_filter_u_and_change_accordingly.py
@@ -1,0 +1,52 @@
+"""add filter_u and change accordingly
+
+Revision ID: 5df293bb75f2
+Revises: a251bdccb11f
+Create Date: 2026-05-20 18:18:28.628076
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5df293bb75f2'
+down_revision = 'a251bdccb11f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('fluxstd', sa.Column('psf_mag_u', sa.Float(), nullable=True, comment='u-band PSF magnitude (AB mag)'))
+    op.add_column('fluxstd', sa.Column('psf_mag_error_u', sa.Float(), nullable=True, comment='Error in u-band PSF magnitude (AB mag)'))
+    op.add_column('fluxstd', sa.Column('psf_flux_u', sa.Float(), nullable=True, comment='u-band PSF flux (nJy)'))
+    op.add_column('fluxstd', sa.Column('psf_flux_error_u', sa.Float(), nullable=True, comment='Error in u-band PSF flux (nJy)'))
+    op.add_column('fluxstd', sa.Column('filter_u', sa.String(), nullable=True, comment='u-band filter (u_sdss, u_cfht, etc.)'))
+    op.create_foreign_key('fluxstd_filter_u_fkey', 'fluxstd', 'filter_name', ['filter_u'], ['filter_name'])
+    op.add_column('target', sa.Column('fiber_mag_u', sa.Float(), nullable=True, comment='u-band magnitude within a fiber (AB mag)'))
+    op.add_column('target', sa.Column('psf_mag_u', sa.Float(), nullable=True, comment='u-band PSF magnitude (AB mag)'))
+    op.add_column('target', sa.Column('psf_mag_error_u', sa.Float(), nullable=True, comment='Error in u-band PSF magnitude (AB mag)'))
+    op.add_column('target', sa.Column('psf_flux_u', sa.Float(), nullable=True, comment='u-band PSF flux (nJy)'))
+    op.add_column('target', sa.Column('psf_flux_error_u', sa.Float(), nullable=True, comment='Error in u-band PSF flux (nJy)'))
+    op.add_column('target', sa.Column('total_flux_u', sa.Float(), nullable=True, comment='u-band total flux (nJy)'))
+    op.add_column('target', sa.Column('total_flux_error_u', sa.Float(), nullable=True, comment='Error in u-band total flux (nJy)'))
+    op.add_column('target', sa.Column('filter_u', sa.String(), nullable=True, comment='u-band filter (u_sdss, u_cfht, etc.)'))
+    op.create_foreign_key('target_filter_u_fkey', 'target', 'filter_name', ['filter_u'], ['filter_name'])
+
+
+def downgrade():
+    op.drop_constraint('target_filter_u_fkey', 'target', type_='foreignkey')
+    op.drop_column('target', 'filter_u')
+    op.drop_column('target', 'total_flux_error_u')
+    op.drop_column('target', 'total_flux_u')
+    op.drop_column('target', 'psf_flux_error_u')
+    op.drop_column('target', 'psf_flux_u')
+    op.drop_column('target', 'psf_mag_error_u')
+    op.drop_column('target', 'psf_mag_u')
+    op.drop_column('target', 'fiber_mag_u')
+    op.drop_constraint('fluxstd_filter_u_fkey', 'fluxstd', type_='foreignkey')
+    op.drop_column('fluxstd', 'filter_u')
+    op.drop_column('fluxstd', 'psf_flux_error_u')
+    op.drop_column('fluxstd', 'psf_flux_u')
+    op.drop_column('fluxstd', 'psf_mag_error_u')
+    op.drop_column('fluxstd', 'psf_mag_u')

--- a/alembic/pfsa-db01-gb/alembic/versions/20260521-090910_31f82c75c58d_add_filter_v_and_change_accordingly.py
+++ b/alembic/pfsa-db01-gb/alembic/versions/20260521-090910_31f82c75c58d_add_filter_v_and_change_accordingly.py
@@ -1,0 +1,72 @@
+"""add filter_v and change accordingly
+
+Revision ID: 31f82c75c58d
+Revises: 5df293bb75f2
+Create Date: 2026-05-21 09:09:10.662583
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '31f82c75c58d'
+down_revision = '5df293bb75f2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('fluxstd', sa.Column('psf_mag_v', sa.Float(), nullable=True, comment='v-band PSF magnitude (AB mag)'))
+    op.add_column('fluxstd', sa.Column('psf_mag_error_v', sa.Float(), nullable=True, comment='Error in v-band PSF magnitude (AB mag)'))
+    op.add_column('fluxstd', sa.Column('psf_flux_v', sa.Float(), nullable=True, comment='v-band PSF flux (nJy)'))
+    op.add_column('fluxstd', sa.Column('psf_flux_error_v', sa.Float(), nullable=True, comment='Error in v-band PSF flux (nJy)'))
+    op.add_column('fluxstd', sa.Column('filter_v', sa.String(), nullable=True, comment='v-band filter (v_skymapper, v_splus, etc.)'))
+    op.alter_column('fluxstd', 'filter_u',
+               existing_type=sa.VARCHAR(),
+               comment='u-band filter (u_sdss, u_cfht, u_skymapper, etc.)',
+               existing_comment='u-band filter (u_sdss, u_cfht, etc.)',
+               existing_nullable=True)
+    op.create_foreign_key('fluxstd_filter_v_fkey', 'fluxstd', 'filter_name', ['filter_v'], ['filter_name'])
+    op.add_column('target', sa.Column('fiber_mag_v', sa.Float(), nullable=True, comment='v-band magnitude within a fiber (AB mag)'))
+    op.add_column('target', sa.Column('psf_mag_v', sa.Float(), nullable=True, comment='v-band PSF magnitude (AB mag)'))
+    op.add_column('target', sa.Column('psf_mag_error_v', sa.Float(), nullable=True, comment='Error in v-band PSF magnitude (AB mag)'))
+    op.add_column('target', sa.Column('psf_flux_v', sa.Float(), nullable=True, comment='v-band PSF flux (nJy)'))
+    op.add_column('target', sa.Column('psf_flux_error_v', sa.Float(), nullable=True, comment='Error in v-band PSF flux (nJy)'))
+    op.add_column('target', sa.Column('total_flux_v', sa.Float(), nullable=True, comment='v-band total flux (nJy)'))
+    op.add_column('target', sa.Column('total_flux_error_v', sa.Float(), nullable=True, comment='Error in v-band total flux (nJy)'))
+    op.add_column('target', sa.Column('filter_v', sa.String(), nullable=True, comment='v-band filter (v_skymapper, v_splus, etc.)'))
+    op.alter_column('target', 'filter_u',
+               existing_type=sa.VARCHAR(),
+               comment='u-band filter (u_sdss, u_cfht, u_skymapper, etc.)',
+               existing_comment='u-band filter (u_sdss, u_cfht, etc.)',
+               existing_nullable=True)
+    op.create_foreign_key('target_filter_v_fkey', 'target', 'filter_name', ['filter_v'], ['filter_name'])
+
+
+def downgrade():
+    op.drop_constraint('target_filter_v_fkey', 'target', type_='foreignkey')
+    op.alter_column('target', 'filter_u',
+               existing_type=sa.VARCHAR(),
+               comment='u-band filter (u_sdss, u_cfht, etc.)',
+               existing_comment='u-band filter (u_sdss, u_cfht, u_skymapper, etc.)',
+               existing_nullable=True)
+    op.drop_column('target', 'filter_v')
+    op.drop_column('target', 'total_flux_error_v')
+    op.drop_column('target', 'total_flux_v')
+    op.drop_column('target', 'psf_flux_error_v')
+    op.drop_column('target', 'psf_flux_v')
+    op.drop_column('target', 'psf_mag_error_v')
+    op.drop_column('target', 'psf_mag_v')
+    op.drop_column('target', 'fiber_mag_v')
+    op.drop_constraint('fluxstd_filter_v_fkey', 'fluxstd', type_='foreignkey')
+    op.alter_column('fluxstd', 'filter_u',
+               existing_type=sa.VARCHAR(),
+               comment='u-band filter (u_sdss, u_cfht, etc.)',
+               existing_comment='u-band filter (u_sdss, u_cfht, u_skymapper, etc.)',
+               existing_nullable=True)
+    op.drop_column('fluxstd', 'filter_v')
+    op.drop_column('fluxstd', 'psf_flux_error_v')
+    op.drop_column('fluxstd', 'psf_flux_v')
+    op.drop_column('fluxstd', 'psf_mag_error_v')
+    op.drop_column('fluxstd', 'psf_mag_v')

--- a/docs/schema/fluxstd.md
+++ b/docs/schema/fluxstd.md
@@ -26,6 +26,7 @@ Here are the columns in the `fluxstd` table:
 | target_type_id     | int       | `target_type_id` in the `target_type` table (it is `3` for `FLUXSTD`)                                       |        |              | 3       |
 | input_catalog_id   | int       | `input_catalog_id` in the `input_catalog` table (should be in `[3000, 4999]`)                               |        |              |         |
 | psf_mag_u          | float     | PSF magnitude in _u_-band                                                                                   | AB mag |              |         |
+| psf_mag_v          | float     | PSF magnitude in _v_-band                                                                                   | AB mag |              |         |
 | psf_mag_g          | float     | PSF magnitude in _g_-band                                                                                   | AB mag |              |         |
 | psf_mag_r          | float     | PSF magnitude in _r_-band                                                                                   | AB mag |              |         |
 | psf_mag_i          | float     | PSF magnitude in _i_-band                                                                                   | AB mag |              |         |
@@ -33,6 +34,7 @@ Here are the columns in the `fluxstd` table:
 | psf_mag_y          | float     | PSF magnitude in _y_-band                                                                                   | AB mag |              |         |
 | psf_mag_j          | float     | PSF magnitude in _j_-band                                                                                   | AB mag |              |         |
 | psf_mag_error_u    | float     | Error in PSF magnitude in _u_-band                                                                          | AB mag |              |         |
+| psf_mag_error_v    | float     | Error in PSF magnitude in _v_-band                                                                          | AB mag |              |         |
 | psf_mag_error_g    | float     | Error in PSF magnitude in _g_-band                                                                          | AB mag |              |         |
 | psf_mag_error_r    | float     | Error in PSF magnitude in _r_-band                                                                          | AB mag |              |         |
 | psf_mag_error_i    | float     | Error in PSF magnitude in _i_-band                                                                          | AB mag |              |         |
@@ -40,6 +42,7 @@ Here are the columns in the `fluxstd` table:
 | psf_mag_error_y    | float     | Error in PSF magnitude in _y_-band                                                                          | AB mag |              |         |
 | psf_mag_error_j    | float     | Error in PSF magnitude in _j_-band                                                                          | AB mag |              |         |
 | psf_flux_u         | float     | PSF flux in _u_-band                                                                                        | nJy    | (\*)         |         |
+| psf_flux_v         | float     | PSF flux in _v_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_g         | float     | PSF flux in _g_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_r         | float     | PSF flux in _r_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_i         | float     | PSF flux in _i_-band                                                                                        | nJy    | (\*)         |         |
@@ -47,6 +50,7 @@ Here are the columns in the `fluxstd` table:
 | psf_flux_y         | float     | PSF flux in _y_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_j         | float     | PSF flux in _j_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_error_u   | float     | Error in PSF flux in _u_-band                                                                               | nJy    | (\*)         |         |
+| psf_flux_error_v   | float     | Error in PSF flux in _v_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_g   | float     | Error in PSF flux in _g_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_r   | float     | Error in PSF flux in _r_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_i   | float     | Error in PSF flux in _i_-band                                                                               | nJy    | (\*)         |         |
@@ -54,6 +58,7 @@ Here are the columns in the `fluxstd` table:
 | psf_flux_error_y   | float     | Error in PSF flux in _y_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_j   | float     | Error in PSF flux in _j_-band                                                                               | nJy    | (\*)         |         |
 | filter_u           | str       | Photometric band used to measure the PSF flux in _u_-band                                                   |        | (\*)         |         |
+| filter_v           | str       | Photometric band used to measure the PSF flux in _v_-band                                                   |        | (\*)         |         |
 | filter_g           | str       | Photometric band used to measure the PSF flux in _g_-band                                                   |        | (\*)         |         |
 | filter_r           | str       | Photometric band used to measure the PSF flux in _r_-band                                                   |        | (\*)         |         |
 | filter_i           | str       | Photometric band used to measure the PSF flux in _i_-band                                                   |        | (\*)         |         |
@@ -90,7 +95,7 @@ Here are the columns in the `fluxstd` table:
 
 - `target_type_id` references the `target_type_id` in the `target_type` table.
 - `input_catalog_id` references the `input_catalog_id` in the `input_catalog` table.
-- `filter_{u,g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
+- `filter_{u,v,g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
 
 ## Notes
 

--- a/docs/schema/fluxstd.md
+++ b/docs/schema/fluxstd.md
@@ -25,30 +25,35 @@ Here are the columns in the `fluxstd` table:
 | patch              | int       | Patch defined by, e.g., the HSC pipeline                                                                    |        |              |         |
 | target_type_id     | int       | `target_type_id` in the `target_type` table (it is `3` for `FLUXSTD`)                                       |        |              | 3       |
 | input_catalog_id   | int       | `input_catalog_id` in the `input_catalog` table (should be in `[3000, 4999]`)                               |        |              |         |
+| psf_mag_u          | float     | PSF magnitude in _u_-band                                                                                   | AB mag |              |         |
 | psf_mag_g          | float     | PSF magnitude in _g_-band                                                                                   | AB mag |              |         |
 | psf_mag_r          | float     | PSF magnitude in _r_-band                                                                                   | AB mag |              |         |
 | psf_mag_i          | float     | PSF magnitude in _i_-band                                                                                   | AB mag |              |         |
 | psf_mag_z          | float     | PSF magnitude in _z_-band                                                                                   | AB mag |              |         |
 | psf_mag_y          | float     | PSF magnitude in _y_-band                                                                                   | AB mag |              |         |
 | psf_mag_j          | float     | PSF magnitude in _j_-band                                                                                   | AB mag |              |         |
+| psf_mag_error_u    | float     | Error in PSF magnitude in _u_-band                                                                          | AB mag |              |         |
 | psf_mag_error_g    | float     | Error in PSF magnitude in _g_-band                                                                          | AB mag |              |         |
 | psf_mag_error_r    | float     | Error in PSF magnitude in _r_-band                                                                          | AB mag |              |         |
 | psf_mag_error_i    | float     | Error in PSF magnitude in _i_-band                                                                          | AB mag |              |         |
 | psf_mag_error_z    | float     | Error in PSF magnitude in _z_-band                                                                          | AB mag |              |         |
 | psf_mag_error_y    | float     | Error in PSF magnitude in _y_-band                                                                          | AB mag |              |         |
 | psf_mag_error_j    | float     | Error in PSF magnitude in _j_-band                                                                          | AB mag |              |         |
+| psf_flux_u         | float     | PSF flux in _u_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_g         | float     | PSF flux in _g_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_r         | float     | PSF flux in _r_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_i         | float     | PSF flux in _i_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_z         | float     | PSF flux in _z_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_y         | float     | PSF flux in _y_-band                                                                                        | nJy    | (\*)         |         |
 | psf_flux_j         | float     | PSF flux in _j_-band                                                                                        | nJy    | (\*)         |         |
+| psf_flux_error_u   | float     | Error in PSF flux in _u_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_g   | float     | Error in PSF flux in _g_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_r   | float     | Error in PSF flux in _r_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_i   | float     | Error in PSF flux in _i_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_z   | float     | Error in PSF flux in _z_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_y   | float     | Error in PSF flux in _y_-band                                                                               | nJy    | (\*)         |         |
 | psf_flux_error_j   | float     | Error in PSF flux in _j_-band                                                                               | nJy    | (\*)         |         |
+| filter_u           | str       | Photometric band used to measure the PSF flux in _u_-band                                                   |        | (\*)         |         |
 | filter_g           | str       | Photometric band used to measure the PSF flux in _g_-band                                                   |        | (\*)         |         |
 | filter_r           | str       | Photometric band used to measure the PSF flux in _r_-band                                                   |        | (\*)         |         |
 | filter_i           | str       | Photometric band used to measure the PSF flux in _i_-band                                                   |        | (\*)         |         |
@@ -85,7 +90,7 @@ Here are the columns in the `fluxstd` table:
 
 - `target_type_id` references the `target_type_id` in the `target_type` table.
 - `input_catalog_id` references the `input_catalog_id` in the `input_catalog` table.
-- `filter_{g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
+- `filter_{u,g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
 
 ## Notes
 

--- a/docs/schema/target.md
+++ b/docs/schema/target.md
@@ -24,48 +24,56 @@ Here are the columns in the `target` table:
 | patch                  | int       | Patch defined by, e.g., the HSC pipeline                                                         |        |              |         |
 | target_type_id         | int       | `target_type_id` in the `target_type` table                                                      |        |              |         |
 | input_catalog_id       | int       | `input_catalog_id` in the `input_catalog` table                                                  |        |              |         |
+| fiber_mag_u            | float     | (Obsolete) Fiber magnitude in _u_-band                                                           | AB mag |              |         |
 | fiber_mag_g            | float     | (Obsolete) Fiber magnitude in _g_-band                                                           | AB mag |              |         |
 | fiber_mag_r            | float     | (Obsolete) Fiber magnitude in _r_-band                                                           | AB mag |              |         |
 | fiber_mag_i            | float     | (Obsolete) Fiber magnitude in _i_-band                                                           | AB mag |              |         |
 | fiber_mag_z            | float     | (Obsolete) Fiber magnitude in _z_-band                                                           | AB mag |              |         |
 | fiber_mag_y            | float     | (Obsolete) Fiber magnitude in _y_-band                                                           | AB mag |              |         |
 | fiber_mag_j            | float     | (Obsolete) Fiber magnitude in _j_-band                                                           | AB mag |              |         |
+| psf_mag_u              | float     | (Obsolete) PSF magnitude in _u_-band                                                             | AB mag |              |         |
 | psf_mag_g              | float     | (Obsolete) PSF magnitude in _g_-band                                                             | AB mag |              |         |
 | psf_mag_r              | float     | (Obsolete) PSF magnitude in _r_-band                                                             | AB mag |              |         |
 | psf_mag_i              | float     | (Obsolete) PSF magnitude in _i_-band                                                             | AB mag |              |         |
 | psf_mag_z              | float     | (Obsolete) PSF magnitude in _z_-band                                                             | AB mag |              |         |
 | psf_mag_y              | float     | (Obsolete) PSF magnitude in _y_-band                                                             | AB mag |              |         |
 | psf_mag_j              | float     | (Obsolete) PSF magnitude in _j_-band                                                             | AB mag |              |         |
+| psf_mag_error_u        | float     | (Obsolete) Error in PSF magnitude in _u_-band                                                    | AB mag |              |         |
 | psf_mag_error_g        | float     | (Obsolete) Error in PSF magnitude in _g_-band                                                    | AB mag |              |         |
 | psf_mag_error_r        | float     | (Obsolete) Error in PSF magnitude in _r_-band                                                    | AB mag |              |         |
 | psf_mag_error_i        | float     | (Obsolete) Error in PSF magnitude in _i_-band                                                    | AB mag |              |         |
 | psf_mag_error_z        | float     | (Obsolete) Error in PSF magnitude in _z_-band                                                    | AB mag |              |         |
 | psf_mag_error_y        | float     | (Obsolete) Error in PSF magnitude in _y_-band                                                    | AB mag |              |         |
 | psf_mag_error_j        | float     | (Obsolete) Error in PSF magnitude in _j_-band                                                    | AB mag |              |         |
+| psf_flux_u             | float     | PSF flux in _u_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_g             | float     | PSF flux in _g_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_r             | float     | PSF flux in _r_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_i             | float     | PSF flux in _i_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_z             | float     | PSF flux in _z_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_y             | float     | PSF flux in _y_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_j             | float     | PSF flux in _j_-band                                                                             | nJy    | (\*)         |         |
+| psf_flux_error_u       | float     | Error in PSF flux in _u_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_g       | float     | Error in PSF flux in _g_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_r       | float     | Error in PSF flux in _r_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_i       | float     | Error in PSF flux in _i_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_z       | float     | Error in PSF flux in _z_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_y       | float     | Error in PSF flux in _y_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_j       | float     | Error in PSF flux in _j_-band                                                                    | nJy    | (\*)         |         |
+| total_flux_u           | float     | Total flux in _u_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_g           | float     | Total flux in _g_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_r           | float     | Total flux in _r_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_i           | float     | Total flux in _i_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_z           | float     | Total flux in _z_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_y           | float     | Total flux in _y_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_j           | float     | Total flux in _j_-band                                                                           | nJy    | (\*)         |         |
+| total_flux_error_u     | float     | Error in total flux in _u_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_g     | float     | Error in total flux in _g_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_r     | float     | Error in total flux in _r_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_i     | float     | Error in total flux in _i_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_z     | float     | Error in total flux in _z_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_y     | float     | Error in total flux in _y_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_j     | float     | Error in total flux in _j_-band                                                                  | nJy    | (\*)         |         |
+| filter_u               | str       | Photometric band used to measure the PSF flux in _u_-band                                        |        | (\*)         |         |
 | filter_g               | str       | Photometric band used to measure the PSF flux in _g_-band                                        |        | (\*)         |         |
 | filter_r               | str       | Photometric band used to measure the PSF flux in _r_-band                                        |        | (\*)         |         |
 | filter_i               | str       | Photometric band used to measure the PSF flux in _i_-band                                        |        | (\*)         |         |
@@ -97,7 +105,7 @@ Here are the columns in the `target` table:
 - `proposal_id` references the `proposal_id` in the `proposal` table.
 - `target_type_id` references the `target_type_id` in the `target_type` table.
 - `input_catalog_id` references the `input_catalog_id` in the `input_catalog` table.
-- `filter_{g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
+- `filter_{u,g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
 - `qa_reference_arm` references the `name` in the `pfs_arm` table.
 
 ## Notes

--- a/docs/schema/target.md
+++ b/docs/schema/target.md
@@ -25,6 +25,7 @@ Here are the columns in the `target` table:
 | target_type_id         | int       | `target_type_id` in the `target_type` table                                                      |        |              |         |
 | input_catalog_id       | int       | `input_catalog_id` in the `input_catalog` table                                                  |        |              |         |
 | fiber_mag_u            | float     | (Obsolete) Fiber magnitude in _u_-band                                                           | AB mag |              |         |
+| fiber_mag_v            | float     | (Obsolete) Fiber magnitude in _v_-band                                                           | AB mag |              |         |
 | fiber_mag_g            | float     | (Obsolete) Fiber magnitude in _g_-band                                                           | AB mag |              |         |
 | fiber_mag_r            | float     | (Obsolete) Fiber magnitude in _r_-band                                                           | AB mag |              |         |
 | fiber_mag_i            | float     | (Obsolete) Fiber magnitude in _i_-band                                                           | AB mag |              |         |
@@ -32,6 +33,7 @@ Here are the columns in the `target` table:
 | fiber_mag_y            | float     | (Obsolete) Fiber magnitude in _y_-band                                                           | AB mag |              |         |
 | fiber_mag_j            | float     | (Obsolete) Fiber magnitude in _j_-band                                                           | AB mag |              |         |
 | psf_mag_u              | float     | (Obsolete) PSF magnitude in _u_-band                                                             | AB mag |              |         |
+| psf_mag_v              | float     | (Obsolete) PSF magnitude in _v_-band                                                             | AB mag |              |         |
 | psf_mag_g              | float     | (Obsolete) PSF magnitude in _g_-band                                                             | AB mag |              |         |
 | psf_mag_r              | float     | (Obsolete) PSF magnitude in _r_-band                                                             | AB mag |              |         |
 | psf_mag_i              | float     | (Obsolete) PSF magnitude in _i_-band                                                             | AB mag |              |         |
@@ -39,6 +41,7 @@ Here are the columns in the `target` table:
 | psf_mag_y              | float     | (Obsolete) PSF magnitude in _y_-band                                                             | AB mag |              |         |
 | psf_mag_j              | float     | (Obsolete) PSF magnitude in _j_-band                                                             | AB mag |              |         |
 | psf_mag_error_u        | float     | (Obsolete) Error in PSF magnitude in _u_-band                                                    | AB mag |              |         |
+| psf_mag_error_v        | float     | (Obsolete) Error in PSF magnitude in _v_-band                                                    | AB mag |              |         |
 | psf_mag_error_g        | float     | (Obsolete) Error in PSF magnitude in _g_-band                                                    | AB mag |              |         |
 | psf_mag_error_r        | float     | (Obsolete) Error in PSF magnitude in _r_-band                                                    | AB mag |              |         |
 | psf_mag_error_i        | float     | (Obsolete) Error in PSF magnitude in _i_-band                                                    | AB mag |              |         |
@@ -46,6 +49,7 @@ Here are the columns in the `target` table:
 | psf_mag_error_y        | float     | (Obsolete) Error in PSF magnitude in _y_-band                                                    | AB mag |              |         |
 | psf_mag_error_j        | float     | (Obsolete) Error in PSF magnitude in _j_-band                                                    | AB mag |              |         |
 | psf_flux_u             | float     | PSF flux in _u_-band                                                                             | nJy    | (\*)         |         |
+| psf_flux_v             | float     | PSF flux in _v_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_g             | float     | PSF flux in _g_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_r             | float     | PSF flux in _r_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_i             | float     | PSF flux in _i_-band                                                                             | nJy    | (\*)         |         |
@@ -53,6 +57,7 @@ Here are the columns in the `target` table:
 | psf_flux_y             | float     | PSF flux in _y_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_j             | float     | PSF flux in _j_-band                                                                             | nJy    | (\*)         |         |
 | psf_flux_error_u       | float     | Error in PSF flux in _u_-band                                                                    | nJy    | (\*)         |         |
+| psf_flux_error_v       | float     | Error in PSF flux in _v_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_g       | float     | Error in PSF flux in _g_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_r       | float     | Error in PSF flux in _r_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_i       | float     | Error in PSF flux in _i_-band                                                                    | nJy    | (\*)         |         |
@@ -60,6 +65,7 @@ Here are the columns in the `target` table:
 | psf_flux_error_y       | float     | Error in PSF flux in _y_-band                                                                    | nJy    | (\*)         |         |
 | psf_flux_error_j       | float     | Error in PSF flux in _j_-band                                                                    | nJy    | (\*)         |         |
 | total_flux_u           | float     | Total flux in _u_-band                                                                           | nJy    | (\*)         |         |
+| total_flux_v           | float     | Total flux in _v_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_g           | float     | Total flux in _g_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_r           | float     | Total flux in _r_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_i           | float     | Total flux in _i_-band                                                                           | nJy    | (\*)         |         |
@@ -67,6 +73,7 @@ Here are the columns in the `target` table:
 | total_flux_y           | float     | Total flux in _y_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_j           | float     | Total flux in _j_-band                                                                           | nJy    | (\*)         |         |
 | total_flux_error_u     | float     | Error in total flux in _u_-band                                                                  | nJy    | (\*)         |         |
+| total_flux_error_v     | float     | Error in total flux in _v_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_g     | float     | Error in total flux in _g_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_r     | float     | Error in total flux in _r_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_i     | float     | Error in total flux in _i_-band                                                                  | nJy    | (\*)         |         |
@@ -74,6 +81,7 @@ Here are the columns in the `target` table:
 | total_flux_error_y     | float     | Error in total flux in _y_-band                                                                  | nJy    | (\*)         |         |
 | total_flux_error_j     | float     | Error in total flux in _j_-band                                                                  | nJy    | (\*)         |         |
 | filter_u               | str       | Photometric band used to measure the PSF flux in _u_-band                                        |        | (\*)         |         |
+| filter_v               | str       | Photometric band used to measure the PSF flux in _v_-band                                        |        | (\*)         |         |
 | filter_g               | str       | Photometric band used to measure the PSF flux in _g_-band                                        |        | (\*)         |         |
 | filter_r               | str       | Photometric band used to measure the PSF flux in _r_-band                                        |        | (\*)         |         |
 | filter_i               | str       | Photometric band used to measure the PSF flux in _i_-band                                        |        | (\*)         |         |
@@ -105,7 +113,7 @@ Here are the columns in the `target` table:
 - `proposal_id` references the `proposal_id` in the `proposal` table.
 - `target_type_id` references the `target_type_id` in the `target_type` table.
 - `input_catalog_id` references the `input_catalog_id` in the `input_catalog` table.
-- `filter_{u,g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
+- `filter_{u,v,g,r,i,z,y,j}` references the `filter_name` in the `filter_name` table.
 - `qa_reference_arm` references the `name` in the `pfs_arm` table.
 
 ## Notes

--- a/src/targetdb/models/fluxstd.py
+++ b/src/targetdb/models/fluxstd.py
@@ -97,6 +97,7 @@ class fluxstd(Base):
     )
 
     psf_mag_u = Column(Float, comment="u-band PSF magnitude (AB mag)")
+    psf_mag_v = Column(Float, comment="v-band PSF magnitude (AB mag)")
     psf_mag_g = Column(Float, comment="g-band PSF magnitude (AB mag)")
     psf_mag_r = Column(Float, comment="r-band PSF magnitude (AB mag)")
     psf_mag_i = Column(Float, comment="i-band PSF magnitude (AB mag)")
@@ -105,6 +106,7 @@ class fluxstd(Base):
     psf_mag_j = Column(Float, comment="J band PSF magnitude (AB mag)")
 
     psf_mag_error_u = Column(Float, comment="Error in u-band PSF magnitude (AB mag)")
+    psf_mag_error_v = Column(Float, comment="Error in v-band PSF magnitude (AB mag)")
     psf_mag_error_g = Column(Float, comment="Error in g-band PSF magnitude (AB mag)")
     psf_mag_error_r = Column(Float, comment="Error in r-band PSF magnitude (AB mag)")
     psf_mag_error_i = Column(Float, comment="Error in i-band PSF magnitude (AB mag)")
@@ -113,6 +115,7 @@ class fluxstd(Base):
     psf_mag_error_j = Column(Float, comment="Error in J band PSF magnitude (AB mag)")
 
     psf_flux_u = Column(Float, comment="u-band PSF flux (nJy)")
+    psf_flux_v = Column(Float, comment="v-band PSF flux (nJy)")
     psf_flux_g = Column(Float, comment="g-band PSF flux (nJy)")
     psf_flux_r = Column(Float, comment="r-band PSF flux (nJy)")
     psf_flux_i = Column(Float, comment="i-band PSF flux (nJy)")
@@ -121,6 +124,7 @@ class fluxstd(Base):
     psf_flux_j = Column(Float, comment="J band PSF flux (nJy)")
 
     psf_flux_error_u = Column(Float, comment="Error in u-band PSF flux (nJy)")
+    psf_flux_error_v = Column(Float, comment="Error in v-band PSF flux (nJy)")
     psf_flux_error_g = Column(Float, comment="Error in g-band PSF flux (nJy)")
     psf_flux_error_r = Column(Float, comment="Error in r-band PSF flux (nJy)")
     psf_flux_error_i = Column(Float, comment="Error in i-band PSF flux (nJy)")
@@ -131,7 +135,12 @@ class fluxstd(Base):
     filter_u = Column(
         String,
         ForeignKey("filter_name.filter_name"),
-        comment="u-band filter (u_sdss, u_cfht, etc.)",
+        comment="u-band filter (u_sdss, u_cfht, u_skymapper, etc.)",
+    )
+    filter_v = Column(
+        String,
+        ForeignKey("filter_name.filter_name"),
+        comment="v-band filter (v_skymapper, v_splus, etc.)",
     )
     filter_g = Column(
         String,
@@ -249,6 +258,7 @@ class fluxstd(Base):
     # tried to make a relationship to filter_name table
     # ref: https://docs.sqlalchemy.org/en/14/orm/join_conditions.html
     filter_u_rels = relationship(filter_name, foreign_keys=[filter_u])
+    filter_v_rels = relationship(filter_name, foreign_keys=[filter_v])
     filter_g_rels = relationship(filter_name, foreign_keys=[filter_g])
     filter_r_rels = relationship(filter_name, foreign_keys=[filter_r])
     filter_i_rels = relationship(filter_name, foreign_keys=[filter_i])
@@ -273,6 +283,7 @@ class fluxstd(Base):
         target_type_id,
         input_catalog_id,
         psf_mag_u,
+        psf_mag_v,
         psf_mag_g,
         psf_mag_r,
         psf_mag_i,
@@ -280,6 +291,7 @@ class fluxstd(Base):
         psf_mag_y,
         psf_mag_j,
         psf_mag_error_u,
+        psf_mag_error_v,
         psf_mag_error_g,
         psf_mag_error_r,
         psf_mag_error_i,
@@ -287,6 +299,7 @@ class fluxstd(Base):
         psf_mag_error_y,
         psf_mag_error_j,
         psf_flux_u,
+        psf_flux_v,
         psf_flux_g,
         psf_flux_r,
         psf_flux_i,
@@ -294,6 +307,7 @@ class fluxstd(Base):
         psf_flux_y,
         psf_flux_j,
         psf_flux_error_u,
+        psf_flux_error_v,
         psf_flux_error_g,
         psf_flux_error_r,
         psf_flux_error_i,
@@ -301,6 +315,7 @@ class fluxstd(Base):
         psf_flux_error_y,
         psf_flux_error_j,
         filter_u,
+        filter_v,
         filter_g,
         filter_r,
         filter_i,
@@ -341,6 +356,7 @@ class fluxstd(Base):
         self.target_type_id = target_type_id
         self.input_catalog_id = input_catalog_id
         self.psf_mag_u = psf_mag_u
+        self.psf_mag_v = psf_mag_v
         self.psf_mag_g = psf_mag_g
         self.psf_mag_r = psf_mag_r
         self.psf_mag_i = psf_mag_i
@@ -348,6 +364,7 @@ class fluxstd(Base):
         self.psf_mag_y = psf_mag_y
         self.psf_mag_j = psf_mag_j
         self.psf_mag_error_u = psf_mag_error_u
+        self.psf_mag_error_v = psf_mag_error_v
         self.psf_mag_error_g = psf_mag_error_g
         self.psf_mag_error_r = psf_mag_error_r
         self.psf_mag_error_i = psf_mag_error_i
@@ -355,6 +372,7 @@ class fluxstd(Base):
         self.psf_mag_error_y = psf_mag_error_y
         self.psf_mag_error_j = psf_mag_error_j
         self.psf_flux_u = psf_flux_u
+        self.psf_flux_v = psf_flux_v
         self.psf_flux_g = psf_flux_g
         self.psf_flux_r = psf_flux_r
         self.psf_flux_i = psf_flux_i
@@ -362,6 +380,7 @@ class fluxstd(Base):
         self.psf_flux_y = psf_flux_y
         self.psf_flux_j = psf_flux_j
         self.psf_flux_error_u = psf_flux_error_u
+        self.psf_flux_error_v = psf_flux_error_v
         self.psf_flux_error_g = psf_flux_error_g
         self.psf_flux_error_r = psf_flux_error_r
         self.psf_flux_error_i = psf_flux_error_i
@@ -369,6 +388,7 @@ class fluxstd(Base):
         self.psf_flux_error_y = psf_flux_error_y
         self.psf_flux_error_j = psf_flux_error_j
         self.filter_u = filter_u
+        self.filter_v = filter_v
         self.filter_g = filter_g
         self.filter_r = filter_r
         self.filter_i = filter_i

--- a/src/targetdb/models/fluxstd.py
+++ b/src/targetdb/models/fluxstd.py
@@ -96,6 +96,7 @@ class fluxstd(Base):
         comment="input_catalog_id from the input_catalog table",
     )
 
+    psf_mag_u = Column(Float, comment="u-band PSF magnitude (AB mag)")
     psf_mag_g = Column(Float, comment="g-band PSF magnitude (AB mag)")
     psf_mag_r = Column(Float, comment="r-band PSF magnitude (AB mag)")
     psf_mag_i = Column(Float, comment="i-band PSF magnitude (AB mag)")
@@ -103,6 +104,7 @@ class fluxstd(Base):
     psf_mag_y = Column(Float, comment="y-band PSF magnitude (AB mag)")
     psf_mag_j = Column(Float, comment="J band PSF magnitude (AB mag)")
 
+    psf_mag_error_u = Column(Float, comment="Error in u-band PSF magnitude (AB mag)")
     psf_mag_error_g = Column(Float, comment="Error in g-band PSF magnitude (AB mag)")
     psf_mag_error_r = Column(Float, comment="Error in r-band PSF magnitude (AB mag)")
     psf_mag_error_i = Column(Float, comment="Error in i-band PSF magnitude (AB mag)")
@@ -110,6 +112,7 @@ class fluxstd(Base):
     psf_mag_error_y = Column(Float, comment="Error in y-band PSF magnitude (AB mag)")
     psf_mag_error_j = Column(Float, comment="Error in J band PSF magnitude (AB mag)")
 
+    psf_flux_u = Column(Float, comment="u-band PSF flux (nJy)")
     psf_flux_g = Column(Float, comment="g-band PSF flux (nJy)")
     psf_flux_r = Column(Float, comment="r-band PSF flux (nJy)")
     psf_flux_i = Column(Float, comment="i-band PSF flux (nJy)")
@@ -117,6 +120,7 @@ class fluxstd(Base):
     psf_flux_y = Column(Float, comment="y-band PSF flux (nJy)")
     psf_flux_j = Column(Float, comment="J band PSF flux (nJy)")
 
+    psf_flux_error_u = Column(Float, comment="Error in u-band PSF flux (nJy)")
     psf_flux_error_g = Column(Float, comment="Error in g-band PSF flux (nJy)")
     psf_flux_error_r = Column(Float, comment="Error in r-band PSF flux (nJy)")
     psf_flux_error_i = Column(Float, comment="Error in i-band PSF flux (nJy)")
@@ -124,13 +128,11 @@ class fluxstd(Base):
     psf_flux_error_y = Column(Float, comment="Error in y-band PSF flux (nJy)")
     psf_flux_error_j = Column(Float, comment="Error in J band PSF flux (nJy)")
 
-    # filter_g = Column(String, comment="g-band filter (g_hsc, g_ps1, g_sdss, etc.)")
-    # filter_r = Column(String, comment="r-band filter (r_hsc, r_ps1, r_sdss, etc.)")
-    # filter_i = Column(String, comment="i-band filter (i_hsc, i_ps1, i_sdss, etc.)")
-    # filter_z = Column(String, comment="z-band filter (z_hsc, z_ps1, z_sdss, etc.)")
-    # filter_y = Column(String, comment="y-band filter (y_hsc, y_ps1, y_sdss, etc.)")
-    # filter_j = Column(String, comment="j-band filter (j_mko, etc.)")
-
+    filter_u = Column(
+        String,
+        ForeignKey("filter_name.filter_name"),
+        comment="u-band filter (u_sdss, u_cfht, etc.)",
+    )
     filter_g = Column(
         String,
         ForeignKey("filter_name.filter_name"),
@@ -246,6 +248,7 @@ class fluxstd(Base):
 
     # tried to make a relationship to filter_name table
     # ref: https://docs.sqlalchemy.org/en/14/orm/join_conditions.html
+    filter_u_rels = relationship(filter_name, foreign_keys=[filter_u])
     filter_g_rels = relationship(filter_name, foreign_keys=[filter_g])
     filter_r_rels = relationship(filter_name, foreign_keys=[filter_r])
     filter_i_rels = relationship(filter_name, foreign_keys=[filter_i])
@@ -269,30 +272,35 @@ class fluxstd(Base):
         patch,
         target_type_id,
         input_catalog_id,
+        psf_mag_u,
         psf_mag_g,
         psf_mag_r,
         psf_mag_i,
         psf_mag_z,
         psf_mag_y,
         psf_mag_j,
+        psf_mag_error_u,
         psf_mag_error_g,
         psf_mag_error_r,
         psf_mag_error_i,
         psf_mag_error_z,
         psf_mag_error_y,
         psf_mag_error_j,
+        psf_flux_u,
         psf_flux_g,
         psf_flux_r,
         psf_flux_i,
         psf_flux_z,
         psf_flux_y,
         psf_flux_j,
+        psf_flux_error_u,
         psf_flux_error_g,
         psf_flux_error_r,
         psf_flux_error_i,
         psf_flux_error_z,
         psf_flux_error_y,
         psf_flux_error_j,
+        filter_u,
         filter_g,
         filter_r,
         filter_i,
@@ -332,30 +340,35 @@ class fluxstd(Base):
         self.patch = patch
         self.target_type_id = target_type_id
         self.input_catalog_id = input_catalog_id
+        self.psf_mag_u = psf_mag_u
         self.psf_mag_g = psf_mag_g
         self.psf_mag_r = psf_mag_r
         self.psf_mag_i = psf_mag_i
         self.psf_mag_z = psf_mag_z
         self.psf_mag_y = psf_mag_y
         self.psf_mag_j = psf_mag_j
+        self.psf_mag_error_u = psf_mag_error_u
         self.psf_mag_error_g = psf_mag_error_g
         self.psf_mag_error_r = psf_mag_error_r
         self.psf_mag_error_i = psf_mag_error_i
         self.psf_mag_error_z = psf_mag_error_z
         self.psf_mag_error_y = psf_mag_error_y
         self.psf_mag_error_j = psf_mag_error_j
+        self.psf_flux_u = psf_flux_u
         self.psf_flux_g = psf_flux_g
         self.psf_flux_r = psf_flux_r
         self.psf_flux_i = psf_flux_i
         self.psf_flux_z = psf_flux_z
         self.psf_flux_y = psf_flux_y
         self.psf_flux_j = psf_flux_j
+        self.psf_flux_error_u = psf_flux_error_u
         self.psf_flux_error_g = psf_flux_error_g
         self.psf_flux_error_r = psf_flux_error_r
         self.psf_flux_error_i = psf_flux_error_i
         self.psf_flux_error_z = psf_flux_error_z
         self.psf_flux_error_y = psf_flux_error_y
         self.psf_flux_error_j = psf_flux_error_j
+        self.filter_u = filter_u
         self.filter_g = filter_g
         self.filter_r = filter_r
         self.filter_i = filter_i

--- a/src/targetdb/models/target.py
+++ b/src/targetdb/models/target.py
@@ -117,6 +117,7 @@ class target(Base):
     )
 
     fiber_mag_u = Column(Float, comment="u-band magnitude within a fiber (AB mag)")
+    fiber_mag_v = Column(Float, comment="v-band magnitude within a fiber (AB mag)")
     fiber_mag_g = Column(Float, comment="g-band magnitude within a fiber (AB mag)")
     fiber_mag_r = Column(Float, comment="r-band magnitude within a fiber (AB mag)")
     fiber_mag_i = Column(Float, comment="i-band magnitude within a fiber (AB mag)")
@@ -125,6 +126,7 @@ class target(Base):
     fiber_mag_j = Column(Float, comment="J band magnitude within a fiber (AB mag)")
 
     psf_mag_u = Column(Float, comment="u-band PSF magnitude (AB mag)")
+    psf_mag_v = Column(Float, comment="v-band PSF magnitude (AB mag)")
     psf_mag_g = Column(Float, comment="g-band PSF magnitude (AB mag)")
     psf_mag_r = Column(Float, comment="r-band PSF magnitude (AB mag)")
     psf_mag_i = Column(Float, comment="i-band PSF magnitude (AB mag)")
@@ -133,6 +135,7 @@ class target(Base):
     psf_mag_j = Column(Float, comment="J band PSF magnitude (AB mag)")
 
     psf_mag_error_u = Column(Float, comment="Error in u-band PSF magnitude (AB mag)")
+    psf_mag_error_v = Column(Float, comment="Error in v-band PSF magnitude (AB mag)")
     psf_mag_error_g = Column(Float, comment="Error in g-band PSF magnitude (AB mag)")
     psf_mag_error_r = Column(Float, comment="Error in r-band PSF magnitude (AB mag)")
     psf_mag_error_i = Column(Float, comment="Error in i-band PSF magnitude (AB mag)")
@@ -141,6 +144,7 @@ class target(Base):
     psf_mag_error_j = Column(Float, comment="Error in J band PSF magnitude (AB mag)")
 
     psf_flux_u = Column(Float, comment="u-band PSF flux (nJy)")
+    psf_flux_v = Column(Float, comment="v-band PSF flux (nJy)")
     psf_flux_g = Column(Float, comment="g-band PSF flux (nJy)")
     psf_flux_r = Column(Float, comment="r-band PSF flux (nJy)")
     psf_flux_i = Column(Float, comment="i-band PSF flux (nJy)")
@@ -149,6 +153,7 @@ class target(Base):
     psf_flux_j = Column(Float, comment="J band PSF flux (nJy)")
 
     psf_flux_error_u = Column(Float, comment="Error in u-band PSF flux (nJy)")
+    psf_flux_error_v = Column(Float, comment="Error in v-band PSF flux (nJy)")
     psf_flux_error_g = Column(Float, comment="Error in g-band PSF flux (nJy)")
     psf_flux_error_r = Column(Float, comment="Error in r-band PSF flux (nJy)")
     psf_flux_error_i = Column(Float, comment="Error in i-band PSF flux (nJy)")
@@ -157,6 +162,7 @@ class target(Base):
     psf_flux_error_j = Column(Float, comment="Error in J band PSF flux (nJy)")
 
     total_flux_u = Column(Float, comment="u-band total flux (nJy)")
+    total_flux_v = Column(Float, comment="v-band total flux (nJy)")
     total_flux_g = Column(Float, comment="g-band total flux (nJy)")
     total_flux_r = Column(Float, comment="r-band total flux (nJy)")
     total_flux_i = Column(Float, comment="i-band total flux (nJy)")
@@ -165,6 +171,7 @@ class target(Base):
     total_flux_j = Column(Float, comment="J band total flux (nJy)")
 
     total_flux_error_u = Column(Float, comment="Error in u-band total flux (nJy)")
+    total_flux_error_v = Column(Float, comment="Error in v-band total flux (nJy)")
     total_flux_error_g = Column(Float, comment="Error in g-band total flux (nJy)")
     total_flux_error_r = Column(Float, comment="Error in r-band total flux (nJy)")
     total_flux_error_i = Column(Float, comment="Error in i-band total flux (nJy)")
@@ -175,7 +182,12 @@ class target(Base):
     filter_u = Column(
         String,
         ForeignKey("filter_name.filter_name"),
-        comment="u-band filter (u_sdss, u_cfht, etc.)",
+        comment="u-band filter (u_sdss, u_cfht, u_skymapper, etc.)",
+    )
+    filter_v = Column(
+        String,
+        ForeignKey("filter_name.filter_name"),
+        comment="v-band filter (v_skymapper, v_splus, etc.)",
     )
     filter_g = Column(
         String,
@@ -281,6 +293,7 @@ class target(Base):
     # tried to make a relationship to filter_name table
     # ref: https://docs.sqlalchemy.org/en/14/orm/join_conditions.html
     filter_u_rels = relationship(filter_name, foreign_keys=[filter_u])
+    filter_v_rels = relationship(filter_name, foreign_keys=[filter_v])
     filter_g_rels = relationship(filter_name, foreign_keys=[filter_g])
     filter_r_rels = relationship(filter_name, foreign_keys=[filter_r])
     filter_i_rels = relationship(filter_name, foreign_keys=[filter_i])
@@ -310,6 +323,7 @@ class target(Base):
         input_catalog_id,
         #
         fiber_mag_u,
+        fiber_mag_v,
         fiber_mag_g,
         fiber_mag_r,
         fiber_mag_i,
@@ -318,6 +332,7 @@ class target(Base):
         fiber_mag_j,
         #
         psf_mag_u,
+        psf_mag_v,
         psf_mag_g,
         psf_mag_r,
         psf_mag_i,
@@ -326,6 +341,7 @@ class target(Base):
         psf_mag_j,
         #
         psf_mag_error_u,
+        psf_mag_error_v,
         psf_mag_error_g,
         psf_mag_error_r,
         psf_mag_error_i,
@@ -334,6 +350,7 @@ class target(Base):
         psf_mag_error_j,
         #
         psf_flux_u,
+        psf_flux_v,
         psf_flux_g,
         psf_flux_r,
         psf_flux_i,
@@ -342,6 +359,7 @@ class target(Base):
         psf_flux_j,
         #
         psf_flux_error_u,
+        psf_flux_error_v,
         psf_flux_error_g,
         psf_flux_error_r,
         psf_flux_error_i,
@@ -350,6 +368,7 @@ class target(Base):
         psf_flux_error_j,
         #
         total_flux_u,
+        total_flux_v,
         total_flux_g,
         total_flux_r,
         total_flux_i,
@@ -358,6 +377,7 @@ class target(Base):
         total_flux_j,
         #
         total_flux_error_u,
+        total_flux_error_v,
         total_flux_error_g,
         total_flux_error_r,
         total_flux_error_i,
@@ -366,6 +386,7 @@ class target(Base):
         total_flux_error_j,
         #
         filter_u,
+        filter_v,
         filter_g,
         filter_r,
         filter_i,
@@ -406,6 +427,7 @@ class target(Base):
         self.input_catalog_id = input_catalog_id
         #
         self.fiber_mag_u = fiber_mag_u
+        self.fiber_mag_v = fiber_mag_v
         self.fiber_mag_g = fiber_mag_g
         self.fiber_mag_r = fiber_mag_r
         self.fiber_mag_i = fiber_mag_i
@@ -414,6 +436,7 @@ class target(Base):
         self.fiber_mag_j = fiber_mag_j
         #
         self.psf_mag_u = psf_mag_u
+        self.psf_mag_v = psf_mag_v
         self.psf_mag_g = psf_mag_g
         self.psf_mag_r = psf_mag_r
         self.psf_mag_i = psf_mag_i
@@ -422,6 +445,7 @@ class target(Base):
         self.psf_mag_j = psf_mag_j
         #
         self.psf_mag_error_u = psf_mag_error_u
+        self.psf_mag_error_v = psf_mag_error_v
         self.psf_mag_error_g = psf_mag_error_g
         self.psf_mag_error_r = psf_mag_error_r
         self.psf_mag_error_i = psf_mag_error_i
@@ -430,6 +454,7 @@ class target(Base):
         self.psf_mag_error_j = psf_mag_error_j
         #
         self.psf_flux_u = psf_flux_u
+        self.psf_flux_v = psf_flux_v
         self.psf_flux_g = psf_flux_g
         self.psf_flux_r = psf_flux_r
         self.psf_flux_i = psf_flux_i
@@ -438,6 +463,7 @@ class target(Base):
         self.psf_flux_j = psf_flux_j
         #
         self.psf_flux_error_u = psf_flux_error_u
+        self.psf_flux_error_v = psf_flux_error_v
         self.psf_flux_error_g = psf_flux_error_g
         self.psf_flux_error_r = psf_flux_error_r
         self.psf_flux_error_i = psf_flux_error_i
@@ -446,6 +472,7 @@ class target(Base):
         self.psf_flux_error_j = psf_flux_error_j
         #
         self.total_flux_u = total_flux_u
+        self.total_flux_v = total_flux_v
         self.total_flux_g = total_flux_g
         self.total_flux_r = total_flux_r
         self.total_flux_i = total_flux_i
@@ -454,6 +481,7 @@ class target(Base):
         self.total_flux_j = total_flux_j
         #
         self.total_flux_error_u = total_flux_error_u
+        self.total_flux_error_v = total_flux_error_v
         self.total_flux_error_g = total_flux_error_g
         self.total_flux_error_r = total_flux_error_r
         self.total_flux_error_i = total_flux_error_i
@@ -462,6 +490,7 @@ class target(Base):
         self.total_flux_error_j = total_flux_error_j
         #
         self.filter_u = filter_u
+        self.filter_v = filter_v
         self.filter_g = filter_g
         self.filter_r = filter_r
         self.filter_i = filter_i

--- a/src/targetdb/models/target.py
+++ b/src/targetdb/models/target.py
@@ -116,6 +116,7 @@ class target(Base):
         comment="Input catalog ID from the input_catalog table",
     )
 
+    fiber_mag_u = Column(Float, comment="u-band magnitude within a fiber (AB mag)")
     fiber_mag_g = Column(Float, comment="g-band magnitude within a fiber (AB mag)")
     fiber_mag_r = Column(Float, comment="r-band magnitude within a fiber (AB mag)")
     fiber_mag_i = Column(Float, comment="i-band magnitude within a fiber (AB mag)")
@@ -123,6 +124,7 @@ class target(Base):
     fiber_mag_y = Column(Float, comment="y-band magnitude within a fiber (AB mag)")
     fiber_mag_j = Column(Float, comment="J band magnitude within a fiber (AB mag)")
 
+    psf_mag_u = Column(Float, comment="u-band PSF magnitude (AB mag)")
     psf_mag_g = Column(Float, comment="g-band PSF magnitude (AB mag)")
     psf_mag_r = Column(Float, comment="r-band PSF magnitude (AB mag)")
     psf_mag_i = Column(Float, comment="i-band PSF magnitude (AB mag)")
@@ -130,6 +132,7 @@ class target(Base):
     psf_mag_y = Column(Float, comment="y-band PSF magnitude (AB mag)")
     psf_mag_j = Column(Float, comment="J band PSF magnitude (AB mag)")
 
+    psf_mag_error_u = Column(Float, comment="Error in u-band PSF magnitude (AB mag)")
     psf_mag_error_g = Column(Float, comment="Error in g-band PSF magnitude (AB mag)")
     psf_mag_error_r = Column(Float, comment="Error in r-band PSF magnitude (AB mag)")
     psf_mag_error_i = Column(Float, comment="Error in i-band PSF magnitude (AB mag)")
@@ -137,6 +140,7 @@ class target(Base):
     psf_mag_error_y = Column(Float, comment="Error in y-band PSF magnitude (AB mag)")
     psf_mag_error_j = Column(Float, comment="Error in J band PSF magnitude (AB mag)")
 
+    psf_flux_u = Column(Float, comment="u-band PSF flux (nJy)")
     psf_flux_g = Column(Float, comment="g-band PSF flux (nJy)")
     psf_flux_r = Column(Float, comment="r-band PSF flux (nJy)")
     psf_flux_i = Column(Float, comment="i-band PSF flux (nJy)")
@@ -144,6 +148,7 @@ class target(Base):
     psf_flux_y = Column(Float, comment="y-band PSF flux (nJy)")
     psf_flux_j = Column(Float, comment="J band PSF flux (nJy)")
 
+    psf_flux_error_u = Column(Float, comment="Error in u-band PSF flux (nJy)")
     psf_flux_error_g = Column(Float, comment="Error in g-band PSF flux (nJy)")
     psf_flux_error_r = Column(Float, comment="Error in r-band PSF flux (nJy)")
     psf_flux_error_i = Column(Float, comment="Error in i-band PSF flux (nJy)")
@@ -151,6 +156,7 @@ class target(Base):
     psf_flux_error_y = Column(Float, comment="Error in y-band PSF flux (nJy)")
     psf_flux_error_j = Column(Float, comment="Error in J band PSF flux (nJy)")
 
+    total_flux_u = Column(Float, comment="u-band total flux (nJy)")
     total_flux_g = Column(Float, comment="g-band total flux (nJy)")
     total_flux_r = Column(Float, comment="r-band total flux (nJy)")
     total_flux_i = Column(Float, comment="i-band total flux (nJy)")
@@ -158,6 +164,7 @@ class target(Base):
     total_flux_y = Column(Float, comment="y-band total flux (nJy)")
     total_flux_j = Column(Float, comment="J band total flux (nJy)")
 
+    total_flux_error_u = Column(Float, comment="Error in u-band total flux (nJy)")
     total_flux_error_g = Column(Float, comment="Error in g-band total flux (nJy)")
     total_flux_error_r = Column(Float, comment="Error in r-band total flux (nJy)")
     total_flux_error_i = Column(Float, comment="Error in i-band total flux (nJy)")
@@ -165,6 +172,11 @@ class target(Base):
     total_flux_error_y = Column(Float, comment="Error in y-band total flux (nJy)")
     total_flux_error_j = Column(Float, comment="Error in J band total flux (nJy)")
 
+    filter_u = Column(
+        String,
+        ForeignKey("filter_name.filter_name"),
+        comment="u-band filter (u_sdss, u_cfht, etc.)",
+    )
     filter_g = Column(
         String,
         ForeignKey("filter_name.filter_name"),
@@ -268,6 +280,7 @@ class target(Base):
 
     # tried to make a relationship to filter_name table
     # ref: https://docs.sqlalchemy.org/en/14/orm/join_conditions.html
+    filter_u_rels = relationship(filter_name, foreign_keys=[filter_u])
     filter_g_rels = relationship(filter_name, foreign_keys=[filter_g])
     filter_r_rels = relationship(filter_name, foreign_keys=[filter_r])
     filter_i_rels = relationship(filter_name, foreign_keys=[filter_i])
@@ -296,6 +309,7 @@ class target(Base):
         target_type_id,
         input_catalog_id,
         #
+        fiber_mag_u,
         fiber_mag_g,
         fiber_mag_r,
         fiber_mag_i,
@@ -303,6 +317,7 @@ class target(Base):
         fiber_mag_y,
         fiber_mag_j,
         #
+        psf_mag_u,
         psf_mag_g,
         psf_mag_r,
         psf_mag_i,
@@ -310,6 +325,7 @@ class target(Base):
         psf_mag_y,
         psf_mag_j,
         #
+        psf_mag_error_u,
         psf_mag_error_g,
         psf_mag_error_r,
         psf_mag_error_i,
@@ -317,6 +333,7 @@ class target(Base):
         psf_mag_error_y,
         psf_mag_error_j,
         #
+        psf_flux_u,
         psf_flux_g,
         psf_flux_r,
         psf_flux_i,
@@ -324,6 +341,7 @@ class target(Base):
         psf_flux_y,
         psf_flux_j,
         #
+        psf_flux_error_u,
         psf_flux_error_g,
         psf_flux_error_r,
         psf_flux_error_i,
@@ -331,6 +349,7 @@ class target(Base):
         psf_flux_error_y,
         psf_flux_error_j,
         #
+        total_flux_u,
         total_flux_g,
         total_flux_r,
         total_flux_i,
@@ -338,6 +357,7 @@ class target(Base):
         total_flux_y,
         total_flux_j,
         #
+        total_flux_error_u,
         total_flux_error_g,
         total_flux_error_r,
         total_flux_error_i,
@@ -345,6 +365,7 @@ class target(Base):
         total_flux_error_y,
         total_flux_error_j,
         #
+        filter_u,
         filter_g,
         filter_r,
         filter_i,
@@ -384,6 +405,7 @@ class target(Base):
         self.target_type_id = target_type_id
         self.input_catalog_id = input_catalog_id
         #
+        self.fiber_mag_u = fiber_mag_u
         self.fiber_mag_g = fiber_mag_g
         self.fiber_mag_r = fiber_mag_r
         self.fiber_mag_i = fiber_mag_i
@@ -391,6 +413,7 @@ class target(Base):
         self.fiber_mag_y = fiber_mag_y
         self.fiber_mag_j = fiber_mag_j
         #
+        self.psf_mag_u = psf_mag_u
         self.psf_mag_g = psf_mag_g
         self.psf_mag_r = psf_mag_r
         self.psf_mag_i = psf_mag_i
@@ -398,6 +421,7 @@ class target(Base):
         self.psf_mag_y = psf_mag_y
         self.psf_mag_j = psf_mag_j
         #
+        self.psf_mag_error_u = psf_mag_error_u
         self.psf_mag_error_g = psf_mag_error_g
         self.psf_mag_error_r = psf_mag_error_r
         self.psf_mag_error_i = psf_mag_error_i
@@ -405,6 +429,7 @@ class target(Base):
         self.psf_mag_error_y = psf_mag_error_y
         self.psf_mag_error_j = psf_mag_error_j
         #
+        self.psf_flux_u = psf_flux_u
         self.psf_flux_g = psf_flux_g
         self.psf_flux_r = psf_flux_r
         self.psf_flux_i = psf_flux_i
@@ -412,6 +437,7 @@ class target(Base):
         self.psf_flux_y = psf_flux_y
         self.psf_flux_j = psf_flux_j
         #
+        self.psf_flux_error_u = psf_flux_error_u
         self.psf_flux_error_g = psf_flux_error_g
         self.psf_flux_error_r = psf_flux_error_r
         self.psf_flux_error_i = psf_flux_error_i
@@ -419,6 +445,7 @@ class target(Base):
         self.psf_flux_error_y = psf_flux_error_y
         self.psf_flux_error_j = psf_flux_error_j
         #
+        self.total_flux_u = total_flux_u
         self.total_flux_g = total_flux_g
         self.total_flux_r = total_flux_r
         self.total_flux_i = total_flux_i
@@ -426,6 +453,7 @@ class target(Base):
         self.total_flux_y = total_flux_y
         self.total_flux_j = total_flux_j
         #
+        self.total_flux_error_u = total_flux_error_u
         self.total_flux_error_g = total_flux_error_g
         self.total_flux_error_r = total_flux_error_r
         self.total_flux_error_i = total_flux_error_i
@@ -433,6 +461,7 @@ class target(Base):
         self.total_flux_error_y = total_flux_error_y
         self.total_flux_error_j = total_flux_error_j
         #
+        self.filter_u = filter_u
         self.filter_g = filter_g
         self.filter_r = filter_r
         self.filter_i = filter_i


### PR DESCRIPTION
## Summary

- Add `filter_u`, `filter_v` (FK → `filter_name`) and corresponding photometric columns (`psf_flux`, `psf_flux_error`, `psf_mag`, `psf_mag_error`, `total_flux`, `total_flux_error`, `fiber_mag`) to the `target` table
- Add the same columns (except `fiber_mag` and `total_flux`) to the `fluxstd` table
- Columns are inserted between the existing u/v and g-band positions (order: u, v, g, r, i, z, y, j)
- FK constraint names follow the established `{table}_{column}_fkey` convention
- Update schema documentation (`docs/schema/target.md`, `docs/schema/fluxstd.md`)
- Include two Alembic migrations for `pfsa-db01-gb`:
  - `20260520-181828_5df293bb75f2`: add u-band columns
  - `20260521-090910_31f82c75c58d`: add v-band columns (also updates `filter_u` comment to include `u_skymapper`)

## Test plan

- [x] Verify models import cleanly (`python -c "from targetdb.models.target import target; from targetdb.models.fluxstd import fluxstd"`)
- [ ] Run existing test suite (`pytest tests/`)
- [x] Apply migrations on dev database and confirm schema matches models
- [ ] Confirm FK constraints `target_filter_u_fkey`, `target_filter_v_fkey`, `fluxstd_filter_u_fkey`, `fluxstd_filter_v_fkey` are present

🤖 Generated with [Claude Code](https://claude.ai/claude-code)